### PR TITLE
why does emotecraft link to cosmetica

### DIFF
--- a/pages/alternatives.vue
+++ b/pages/alternatives.vue
@@ -205,7 +205,7 @@
 
     <div class="flex flex-row gap-4 flex-wrap">
 
-        <NuxtLink to="https://modrinth.com/mod/cosmetica"> <user> Modrinth <LucideDownload /> </user> </NuxtLink>
+        <NuxtLink to="https://modrinth.com/mod/emotecraft"> <user> Modrinth <LucideDownload /> </user> </NuxtLink>
         <NuxtLink to="https://discord.com/invite/6NfdRuE"> <user> Discord <LucideMessageCircleMore /> </user> </NuxtLink>
 
     </div>


### PR DESCRIPTION
or link curseforge (oh no) or just remove emotecraft

it's a tad outdated anyways